### PR TITLE
Potential fix for code scanning alert no. 20: DOM text reinterpreted as HTML

### DIFF
--- a/src/third_party/wiredtiger/src/docs/style/header-web.html
+++ b/src/third_party/wiredtiger/src/docs/style/header-web.html
@@ -39,7 +39,16 @@ $extrastylesheet
     },false);
      </script>
 
-     <select id="version_select" onchange="window.location=window.location.href.replace('$projectbrief',this.value);">
+     <script type="text/javascript">
+     function updateLocation(value) {
+       var allowedValues = ["$projectbrief", "stable", "develop", "mongodb-3.2", "mongodb-3.4"];
+       if (allowedValues.includes(value)) {
+         window.location = window.location.href.replace('$projectbrief', value);
+       }
+     }
+     </script>
+
+     <select id="version_select" onchange="updateLocation(this.value);">
        <option name="$projectbrief" value="$projectbrief">$projectnumber</option>
        <option name="stable" value="stable">Latest stable release</option>
        <option name="develop" value="develop">Current develop branch</option>


### PR DESCRIPTION
Potential fix for [https://github.com/pwnautopilots/mongo/security/code-scanning/20](https://github.com/pwnautopilots/mongo/security/code-scanning/20)

To fix the problem, we need to ensure that the value from the `<select>` element is properly sanitized before being used to modify the `window.location.href`. One way to achieve this is by using a whitelist of allowed values and ensuring that only these values are used in the `replace` method. This approach prevents any arbitrary or malicious input from being used.

We will:
1. Create a whitelist of allowed values.
2. Check if `this.value` is in the whitelist before using it.
3. If it is not in the whitelist, we will not modify the `window.location.href`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
